### PR TITLE
feat(frontend): fix-footer-logo-dark-theme

### DIFF
--- a/src/theme/Footer/index.js
+++ b/src/theme/Footer/index.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, { useEffect, useState } from 'react'
 import clsx from 'clsx';
 
 import Link from '@docusaurus/Link';
@@ -48,15 +48,18 @@ function Footer() {
   const {footer} = themeConfig;
 
   const {copyright, links = [], logo = {}} = footer || {};
-  var logoUrl = useBaseUrl(logo.src);
+  const [logoUrl, setLogoUrl] = useState(useBaseUrl(logo.src));
 
   if (!footer) {
     return null;
   }
 
-  if(isDarkTheme) {
-    logoUrl = 'https://raw.githubusercontent.com/eoscostarica/design-assets/master/logos/eosCR/byw-horizontal-transparent-white.png'
-  }
+  useEffect(() => {
+    if(isDarkTheme)
+      setLogoUrl('https://raw.githubusercontent.com/eoscostarica/design-assets/master/logos/eosCR/byw-horizontal-transparent-white.png')
+    else
+      setLogoUrl(logo.src)
+  }, [isDarkTheme]);
 
   return (
     <footer

--- a/src/theme/Footer/index.js
+++ b/src/theme/Footer/index.js
@@ -9,6 +9,7 @@ import React from 'react';
 import clsx from 'clsx';
 
 import Link from '@docusaurus/Link';
+import useThemeContext from '@theme/hooks/useThemeContext';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import styles from './styles.module.css';
@@ -40,16 +41,21 @@ const FooterLogo = ({url, alt}) => (
 );
 
 function Footer() {
+  const {isDarkTheme} = useThemeContext();
   const context = useDocusaurusContext();
   const {siteConfig = {}} = context;
   const {themeConfig = {}} = siteConfig;
   const {footer} = themeConfig;
 
   const {copyright, links = [], logo = {}} = footer || {};
-  const logoUrl = useBaseUrl(logo.src);
+  var logoUrl = useBaseUrl(logo.src);
 
   if (!footer) {
     return null;
+  }
+
+  if(isDarkTheme) {
+    logoUrl = 'https://raw.githubusercontent.com/eoscostarica/design-assets/master/logos/eosCR/byw-horizontal-transparent-white.png'
   }
 
   return (


### PR DESCRIPTION
### GH Issue

Resolves #220  

### Steps to test
1. Check footer logo in dark mode is visible

#### CheckList
- [ ] Follow proper Markdown format
- [ ] The content is adequate
- [ ] The content is available in both english and spanish
- [ ] I Ran a spell check
