### PR TITLE
fix(sidebar): add markdown-guide content

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -44,6 +44,7 @@ module.exports = {
         'tutorials/hello-world-contract',
         'tutorials/modern-cpp',
         'tutorials/git-workflow-tutorial',
+        'tutorials/markdown-guide',
         'tutorials/github-keys'
       ],
     },


### PR DESCRIPTION
### GH Issue

Resolves #263  

### Steps to test
1. Check markdown-guide content is under tutorial section

#### CheckList
- [ ] Follow proper Markdown format
- [ ] The content is adequate
- [ ] The content is available in both english and spanish
- [ ] I Ran a spell check
