### PR TITLE
docs(tools):  Add page sample nodeos configs

### DIFF
--- a/docs/tools/sample-nodeos-configs.md
+++ b/docs/tools/sample-nodeos-configs.md
@@ -1,0 +1,9 @@
+---
+id: sample-nodeos-configs
+title: Sample Nodeos Configurations 
+sidebar_label: Sample Nodeos Configurations 
+---
+
+For example configurations for different EOSIO node types, you can visit the [Sample Nodeos Configurations](https://github.com/eoscostarica/sample-nodeos-configs) repository, which contains a collection of nodeos configuration files and other helpful resources meant to assist students of the [EOSIO Node Operator](https://training.eos.io/courses/eosio-node-operator) and [EOSIO Blockchain Administrator](https://training.eos.io/courses/eosio-blockchain-adminstrator) courses learn from first-hand experience.
+
+There are also four student lab assignments included in this repository that must be completed by students to obtain the course certification.

--- a/sidebars.js
+++ b/sidebars.js
@@ -65,6 +65,7 @@ module.exports = {
         "tools/glossary",
         "tools/command-line",
         "tools/nodeos-command-line-reference",
+        "tools/sample-nodeos-configs",
         "tools/block-explorers",
         "tools/eosio-sdk-libraries",
         "tools/readme-file-template",


### PR DESCRIPTION
Add a page in the sidebar to link to sample-nodeos-configs repository

### What does this PR do ?

- Resolves #386 
- Add docs/tools/sample-nodeos-configs.md

### Steps to test
1. Open the tools category in the sidebar
2. Open the new link Sample Nodeos Configurations
3. Check the content

#### CheckList
- [ ] Follow proper Markdown format
- [ ] The content is adequate
- [ ] The content is available in both english and spanish
- [ ] I Ran a spell check
