### PR TITLE
feat(open-source-guidelines): Add branch naming convention info

### DIFF
--- a/docs/open-source-guidelines.md
+++ b/docs/open-source-guidelines.md
@@ -25,12 +25,40 @@ New and reopened `pull request` are automatically added to the board in the `In 
 
 When the pull request is closed is moved to the `Done` column automatically. If the pull request closes and issues it is properly stated with the GitHub keywords closes in the pull request it gets automatically moved to the `Done` column too.
 
+## Branch Naming Convention
+
+Develop every pull requests in a topic branch using the following simple convention:
+
+```
+<type>/<task-description>-<issue-number>
+```
+
+* Use always lowercase.
+* Choose the [type](#type).
+* Meaningful and short descriptions.
+* Use hyphens as separators.
+* Use the imperative, present tense: "change" not "changed" nor "changes".
+* Use the ``issue`` number to reference it in the branch.
+
+-**Example**:
+
+```
+feat/new-feature-123
+^--^ ^---------^ ^-^
+  |       |       |
+  |       |       +-> Issue number
+  |       |
+  |       +-> Short description of the task
+  |
+  +-> Type
+```
+
 ## Pull Request General Guidelines
 
 * Please check to make sure that there aren't existing `pull request` attempting to address the `issue` mentioned.
 * Check for related `issues` on the `issue tracker`.
 * Non-trivial changes should be discussed on an issue first.
-* Develop in a topic branch, never on master: `git checkout -b topic-branch`.
+* Develop in a topic branch, never on master: `git checkout -b type/task-issue`.
 * Provide useful `pull request` description.
 * Make well scoped `atomic` pull requests. 1 PR per feature of bug fix.
 * Link the `issue` on the `pull request` description for cross references between code and issues.

--- a/docs/open-source-guidelines.md
+++ b/docs/open-source-guidelines.md
@@ -27,13 +27,13 @@ When the pull request is closed is moved to the `Done` column automatically. If 
 
 ## Branch Naming Convention
 
-Develop every pull requests in a topic branch using the following simple convention:
+Name every branch for your pull requests using the following simple convention:
 
 ```
 <type>/<task-description>-<issue-number>
 ```
 
-* Use always lowercase.
+* Always use lowercase.
 * Choose the [type](#type).
 * Meaningful and short descriptions.
 * Use hyphens as separators.
@@ -50,8 +50,24 @@ feat/new-feature-123
   |       |
   |       +-> Short description of the task
   |
-  +-> Type
+  +-> Type: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|content|devtools
 ```
+
+### Type
+
+* **build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm).
+* **chore**: What a user would not see (changes to the build process, configuration, etc).
+* **ci**: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs).
+* **docs**: Documentation only changes.
+* **feat**: A new feature for the user.
+* **fix**: A bug fix for the user.
+* **perf**: A code change that improves performance.
+* **refactor**: A code change that neither fixes a bug nor adds a feature (renaming a variable).
+* **revert**: Reverts a previous commit.
+* **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc).
+* **test**: Adding missing tests or correcting existing tests.
+* **content**: Adding or removing content.
+* **devtools**: Developer tooling related.
 
 ## Pull Request General Guidelines
 


### PR DESCRIPTION
### Branch Naming Convention

### What does this PR do?

- resolves #474 

### Steps to test
1. Go to "Developer Guidelines"
2. Open "Open Source Guidelines"
3. Check the new content in "Branch Naming Convention"

#### CheckList
- [ ] Follow proper Markdown format
- [ ] The content is adequate
- [ ] The content is available in both English and Spanish
- [ ] I Ran a spell check
