### PR TITLE
Update block-explorers.md

### DIFF
--- a/docs/tools/block-explorers.md
+++ b/docs/tools/block-explorers.md
@@ -16,10 +16,6 @@ https://bloks.io/
 
 https://www.eosx.io/
 
-## EOSQ
-
-https://eosq.app/
-
 ## EOS Flare
 
 https://eosflare.io/


### PR DESCRIPTION
Remove eosq, as it will be unavailable after the Spring 1.0 upgrade
(Elimine eosq, ya que no estará disponible después de la actualización de Spring 1.0)

### Title

Remove EOSQ
(Eliminar EOSQ)

### What does this PR do?

- removes eosq.app from the list of block explorers. 
(Elimina eosq.app de la lista de exploradores de bloques.)

EOSQ uses dfuse, which will be unavailable with the EOS Spring 1.0 release. To avoid dead links, remove EOSQ.
(EOSQ utiliza dfuse, que no estará disponible con la versión EOS Spring 1.0. Para evitar enlaces inactivos, elimine EOSQ)

### Steps to test
1. Review formatting

#### CheckList
- [x] Follow proper Markdown format
- [x] The content is adequate
- [x] The content is available in both english and spanish
- [x] I Ran a spell check
